### PR TITLE
21 capi pause support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -136,14 +136,12 @@ func main() {
 
 	if err = (&controlplanecontroller.K3kControlPlaneReconciler{
 		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "K3kControlPlane")
 		os.Exit(1)
 	}
 	if err = (&infrastructurecontroller.K3kClusterReconciler{
 		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "K3kCluster")
 		os.Exit(1)

--- a/internal/controller/controlplane/k3kcontrolplane_controller.go
+++ b/internal/controller/controlplane/k3kcontrolplane_controller.go
@@ -47,7 +47,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,7 +68,6 @@ const (
 // K3kControlPlaneReconciler reconciles a K3kControlPlane object
 type K3kControlPlaneReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/controlplane/k3kcontrolplane_controller_test.go
+++ b/internal/controller/controlplane/k3kcontrolplane_controller_test.go
@@ -70,7 +70,6 @@ var _ = Describe("K3kControlPlane Controller", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &K3kControlPlaneReconciler{
 				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/controller/infrastructure/k3kcluster_controller.go
+++ b/internal/controller/infrastructure/k3kcluster_controller.go
@@ -19,7 +19,6 @@ package infrastructure
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -30,7 +29,6 @@ import (
 // K3kClusterReconciler reconciles a K3kCluster object
 type K3kClusterReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
 }
 
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=k3kclusters,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/infrastructure/k3kcluster_controller_test.go
+++ b/internal/controller/infrastructure/k3kcluster_controller_test.go
@@ -70,7 +70,6 @@ var _ = Describe("K3kCluster Controller", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &K3kClusterReconciler{
 				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{


### PR DESCRIPTION
Added pause support for controlplane and CAPI cluster object. When the capi clsuter object is paused, no reconciliation should happen for the entire cluster. When a specific CR is paused, no reconciliation should happen for that object.

- Added watch to reenqueue controlplane object when the CAPI cluster is updated, but only when the CAPI cluster is not paused
  - Additionally uneful if setting the infrastructure cluster as ready can be done separately from the controlplane reconciliation
- Added watch to reenqueue controlplane object when the infrastructure cluster is updated
  - Mostly useless currently, but will be useful in the future if the infra cluster does something.

Tilt showing all green