### PR TITLE
Updating retry loop to be a bit faster

### DIFF
--- a/internal/controller/controlplane/k3kcontrolplane_controller.go
+++ b/internal/controller/controlplane/k3kcontrolplane_controller.go
@@ -158,9 +158,8 @@ func (r *K3kControlPlaneReconciler) reconcileNormal(ctx context.Context, scope *
 	scope.Info("Reconciled upstream cluster for controlPlane", "upstreamCluster", upstreamCluster, "controlPlane", scope.k3kControlPlane.Name)
 
 	backoff := wait.Backoff{
-		Steps:    5,
-		Duration: 20 * time.Second,
-		Factor:   2,
+		Steps:    20,
+		Duration: 5 * time.Second,
 		Jitter:   0.1,
 	}
 	var config *clientcmdapi.Config


### PR DESCRIPTION
Updates the retry loop on getting a kubeconfig to trigger every 5 seconds as oppsed to every 20 seconds. Also removes the backoff factor. This aims to reduce the time between when the k3k cluster is ready and when it can be used.