### PR TITLE
Fix lint and update `golangci-lint` to latest version (`v2.3.0`)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,13 +1,13 @@
-name: golangci-lint
+name: Lint
 on:
   push:
-    branches:
-      - main
   pull_request:
+
 permissions:
   contents: read
+
 jobs:
-  golangci:
+  lint:
     name: lint
     runs-on: ubuntu-latest
     steps:
@@ -19,7 +19,7 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.59.1
+          version: v2.3
           args: '--timeout=10m'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,37 +1,20 @@
+version: "2"
+
 run:
   allow-parallel-runners: true
-linters-settings:
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-  gocyclo:
-    min-complexity: 10
-  misspell:
-    locale: US
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dupl
     - errcheck
     - errname
     - exhaustive
-    - exportloopref
     - goconst
     - gocritic
-    - gofmt
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -42,22 +25,55 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - wastedassign
     - whitespace
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 10
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gochecknoglobals
+          - golint
+          - gosec
+          - noctx
+          - scopelint
+          - staticcheck
+          - unparam
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - golint
-        - staticcheck
-        - scopelint
-        - gochecknoglobals
-        - noctx
-        - unparam
-        - gosec
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= latest
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v2.3.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -190,7 +190,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/internal/controller/controlplane/k3kcontrolplane_controller.go
+++ b/internal/controller/controlplane/k3kcontrolplane_controller.go
@@ -353,7 +353,6 @@ func (r *K3kControlPlaneReconciler) getUpstreamClusters(ctx context.Context, con
 
 // getKubeconfig retrieves the kubeconfig for the given upstream K3k cluster.
 func (r *K3kControlPlaneReconciler) getKubeconfig(ctx context.Context, upstreamCluster *upstream.Cluster) (*clientcmdapi.Config, error) {
-
 	// TODO: We set the expiry to one year here, but we need to continually keep this up to date
 	cfg := kubeconfig.New()
 	cfg.ExpiryDate = time.Hour * 24 * 365


### PR DESCRIPTION
This PR updates the action to make it run on every push (lint is fast and cheap, and it should be always checked), and it updates the version of golangci-lint to the latest v2.3.0. The old configuration was migrated with the `golangci-lint migrate` command.

It also fixes the only small issue found (whitespace).