### PR TITLE
Add kind to `metadata.yaml`

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,6 +4,7 @@
 #
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
 releaseSeries:
   - major: 0
     minor: 0


### PR DESCRIPTION
This PR fixes the issue with the `clusterctl` v1.11.0. The check will be relaxed in `v1.11.1`, but we still need to match the required spec.

Ref:
- https://github.com/kubernetes-sigs/cluster-api/issues/12712
  - https://github.com/kubernetes-sigs/cluster-api/pull/12714