### PR TITLE
Simplify dev workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,6 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-.PHONY: configure-local
-configure-local:
-	# Using GNU sed, this assumes the image is not surrounded by quotes.
-	sed -i 's|\(IMG ?= \)controller:latest|\1$(TEST_IMAGE)|' Makefile
-	sed -i 's|\(image: \)controller:latest|\1$(TEST_IMAGE)|' config/manager/manager.yaml
-	sed -i 's|\(image: \)controller:latest|\1$(TEST_IMAGE)|' tilt-provider.yaml
-
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out

--- a/README.md
+++ b/README.md
@@ -44,13 +44,6 @@ k3d registry create --port 51111 # Or use a different port.
 k3d cluster create --registry-use $CONTAINER_NAME:$PORT
 ```
 
-#### Configure the project to use the local registry
-
-Ensure you have GNU sed in your PATH.
-
-```bash
-make configure-local TEST_IMAGE=$CONTAINER_NAME:PORT/controller:latest
-```
 
 #### Clone the upstream [CAPI](https://github.com/kubernetes-sigs/cluster-api) project
 
@@ -80,6 +73,7 @@ Some notes:
 #### In the local copy of the CAPI upstream project, run Tilt
 
 ```bash
+export IMG="$CONTAINER_NAME:$PORT/controller:latest"
 tilt up
 ```
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,6 +16,11 @@ resources:
 - ../rbac
 - ../manager
 
+images:
+- name: controller
+  newName: controller
+  newTag: latest
+
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,7 +4,4 @@ kind: Kustomization
 resources:
 - manager.yaml
 
-images:
-- name: controller
-  newName: controller
-  newTag: latest
+images: []


### PR DESCRIPTION
This PR simplify the dev workflow, removing the brittle sed, and using instead an environment variable to setup the build.